### PR TITLE
fix bug on controllers search regex

### DIFF
--- a/src/slim3-annotation/CollectorRoute.php
+++ b/src/slim3-annotation/CollectorRoute.php
@@ -16,7 +16,7 @@ class CollectorRoute
     public function getControllers(string $pathControllers) : array {
 
         $directory = new \RecursiveDirectoryIterator($pathControllers);
-        $regexDirectory = new \RecursiveRegexIterator($directory, '/[\w]+Controller\.php/', \RecursiveRegexIterator::GET_MATCH);
+        $regexDirectory = new \RecursiveRegexIterator($directory, '/[\w]+Controller\.php$/', \RecursiveRegexIterator::GET_MATCH);
 
         $arrayReturn = [];
 


### PR DESCRIPTION
@dilsonjlrjr I found this bug when I rename a ".php" controller.